### PR TITLE
Add MemoryLoader: store rows collection temporarily in memory

### DIFF
--- a/docs/Loaders/MemoryLoader.md
+++ b/docs/Loaders/MemoryLoader.md
@@ -1,0 +1,26 @@
+# MemoryLoader
+
+Loads data into an in-memory collection.
+
+```php
+/** @var \Wizaplace\Etl\Loaders\MemoryLoader $loader */
+$etl->load($loader, '', $options);
+
+// Then retrieve data using the index
+$loader->get('index_for_row_23');
+```
+
+## Options
+
+### Index (required)
+
+The name of `Row` column to uses as in-memory map index.
+
+| Type | Default value |
+|----- | ------------- |
+| string | `null` |
+
+For example, a row extracted from a CSV with a column named `Identifier` would be loaded with this option set:
+```php
+$options = ['index' => 'Identifier'];
+```

--- a/docs/Loaders/README.md
+++ b/docs/Loaders/README.md
@@ -12,3 +12,4 @@ $etl->load($type, $destination, $options);
 
 * [Insert](Insert.md)
 * [Insert/Update](InsertUpdate.md)
+* [MemoryLoader](MemoryLoader.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,5 +21,6 @@
     * [Insert](Loaders/Insert.md)
     * [Insert/Update](Loaders/InsertUpdate.md)
     * [Csv](Loaders/CsvLoader.md)
+    * [MemoryLoader](Loaders/MemoryLoader.md)
 * [Helpers](Helpers.md)
 * [Running Processes](RunningProcesses.md)

--- a/src/Loaders/MemoryLoader.php
+++ b/src/Loaders/MemoryLoader.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @author      Wizacha DevTeam <dev@wizacha.com>
+ * @copyright   Copyright (c) Wizacha
+ * @license     MIT
+ */
+
+declare(strict_types=1);
+
+namespace Wizaplace\Etl\Loaders;
+
+use Wizaplace\Etl\Loaders\Loader;
+use Wizaplace\Etl\Row;
+
+class MemoryLoader extends Loader
+{
+    /** @var string $index Which Row attribute (column) to use as collection index. */
+    protected $index;
+
+    /**
+     * Properties that can be set via the options method. Supports:
+     *   - index: which Row attribute (column) to use as collection index.
+     *
+     * @var string[]
+     */
+    protected $availableOptions = [
+        'index',
+    ];
+
+    /** @var array<string, mixed> In memory loaded collection */
+    protected $collection;
+
+    /**
+     * @inheritDoc
+     */
+    public function load(Row $row): void
+    {
+        $this->collection[$row->get($this->index)] = $row;
+    }
+
+    public function get(string $index): ?Row
+    {
+        return $this->collection[$index] ?? null;
+    }
+}

--- a/src/Transformers/ColumnFilterTransformer.php
+++ b/src/Transformers/ColumnFilterTransformer.php
@@ -23,7 +23,7 @@ class ColumnFilterTransformer extends Transformer
     protected $columns = [];
 
     /**
-     * @var callable $callback Callback function to apply on every Row attribute (column):
+     * @var callable|null $callback Callback function to apply on every Row attribute (column):
      *                            - it takes the column name as first parameter
      *                            - it takes the column value as second parameter
      *                            - it must return a boolean (true to keep the column, false otherwise)

--- a/tests/Loaders/MemoryLoaderTest.php
+++ b/tests/Loaders/MemoryLoaderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @author      Wizacha DevTeam <dev@wizacha.com>
+ * @copyright   Copyright (c) Wizacha
+ * @license     MIT
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Loaders;
+
+use PHPUnit\Framework\TestCase;
+use Wizaplace\Etl\Loaders\MemoryLoader;
+use Wizaplace\Etl\Row;
+
+class MemoryLoaderTest extends TestCase
+{
+    /** @var MemoryLoader */
+    protected $loader;
+
+    public function setUp(): void
+    {
+        $this->loader = new MemoryLoader();
+    }
+
+    public function testLoadMultipleRowsWithValidIndex(): void
+    {
+        $row1 = new Row(['a' => 'b', 'c' => $index1 = 'd']);
+        $row2 = new Row(['a' => 'b2', 'c' => $index2 = 'd2']);
+
+        $this->loader->options(['index' => 'c']);
+        $this->loader->load($row1);
+        $this->loader->load($row2);
+
+        static::assertSame($row2, $this->loader->get($index2));
+        static::assertSame($row1, $this->loader->get($index1));
+    }
+
+    public function testLoadRowWithoutValidIndex(): void
+    {
+        $row = new Row(['a' => 'b', 'c' => $index = 'd']);
+
+        $this->loader->options(['index' => 'k']);
+        $this->loader->load($row);
+
+        static::assertNull($this->loader->get($index));
+    }
+
+    public function testLoadRowGetNotFound(): void
+    {
+        $row = new Row(['a' => 'b', 'c' => $index = 'd']);
+
+        $this->loader->options(['index' => 'c']);
+        $this->loader->load($row);
+
+        static::assertNull($this->loader->get('not found'));
+    }
+}


### PR DESCRIPTION
Example use case: use an ETL instance to create a temporary indexed mapping collection.