### PR TITLE
Add ColumnFilterTransformer: easily filter out multiple Row attributes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
     * [Table](Extractors/Table.md)
     * [XML](Extractors/Xml.md)
 * [Transformers](Transformers/README.md)
+    * [Column Filter](Transformers/ColumnFilterTransformer.md)
     * [Convert Case](Transformers/ConvertCase.md)
     * [JSON Decode](Transformers/JsonDecode.md)
     * [JSON Encode](Transformers/JsonEncode.md)

--- a/docs/Transformers/ColumnFilterTransformer.md
+++ b/docs/Transformers/ColumnFilterTransformer.md
@@ -1,0 +1,41 @@
+# Column Filter
+
+Filter out columns of `Row` object, by their name 
+or using a callback function.
+
+```php
+/** @var \Wizaplace\Etl\Transformers\ColumnFilterTransformer $transformer */
+$etl->transform($transformer, $options);
+```
+
+## Options
+
+### Columns
+
+Column names that will be kept in the `Row` object after transformation. 
+Without additional parameter, any column that doesn't match the name of this parameter will be filtered out. 
+
+| Type | Default value |
+|----- | ------------- |
+| array | `[]` |
+
+```php
+$options = ['columns' => ['name', 'email']];
+```
+
+### Callback
+
+Callback function to apply on each column, taking the column name and value as parameters, and must return a boolean (true to keep the column, false otherwise).
+
+| Type | Default value |
+|----- | ------------- |
+| callable | null |
+
+For example, to exclude empty columns:
+```php
+$options = [
+    'callback' => function (string $columnName, $value): bool {
+        return !empty($columnName) && !empty($value);
+    },
+];
+```

--- a/docs/Transformers/README.md
+++ b/docs/Transformers/README.md
@@ -10,6 +10,7 @@ $etl->transform($transformer, $options);
 
 ## Available transformers types
 
+* [Column Filter](ColumnFilterTransformer.md)
 * [Convert Case](ConvertCase.md)
 * [JSON Decode](JsonDecode.md)
 * [JSON Encode](JsonEncode.md)

--- a/src/Transformers/ColumnFilterTransformer.php
+++ b/src/Transformers/ColumnFilterTransformer.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @author      Wizacha DevTeam <dev@wizacha.com>
+ * @copyright   Copyright (c) Wizacha
+ * @license     MIT
+ */
+
+declare(strict_types=1);
+
+namespace Wizaplace\Etl\Transformers;
+
+use Wizaplace\Etl\Row;
+use Wizaplace\Etl\Transformers\Transformer;
+
+class ColumnFilterTransformer extends Transformer
+{
+    /**
+     * Transformer columns.
+     *
+     * @var string[]
+     */
+    protected $columns = [];
+
+    /**
+     * @var callable $callback Callback function to apply on every Row attribute (column):
+     *                            - it takes the column name as first parameter
+     *                            - it takes the column value as second parameter
+     *                            - it must return a boolean (true to keep the column, false otherwise)
+     */
+    protected $callback;
+
+    /**
+     * Properties that can be set via the options method. Supports:
+     *   - columns (optional): list of column names to keep
+     *   - callback:
+     *
+     * @var string[]
+     */
+    protected $availableOptions = [
+        'columns', 'callback',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function transform(Row $row): void
+    {
+        $rowArray = $row->toArray();
+        $hasColumns = count($this->columns) > 0;
+        $hasCallback = is_callable($this->callback);
+
+        $row->clearAttributes();
+
+        foreach ($rowArray as $columnName => $value) {
+            if (
+                ($hasColumns && false === in_array($columnName, $this->columns, true))
+                || ($hasCallback && false === ($this->callback)($columnName, $value))
+            ) {
+                continue;
+            }
+
+            $row->offsetSet($columnName, $value);
+        }
+    }
+}

--- a/tests/Transformers/ColumnFilterTransformerTest.php
+++ b/tests/Transformers/ColumnFilterTransformerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @author      Wizacha DevTeam <dev@wizacha.com>
+ * @copyright   Copyright (c) Wizacha
+ * @license     MIT
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Transformers;
+
+use PHPUnit\Framework\TestCase;
+use Wizaplace\Etl\Row;
+use Wizaplace\Etl\Transformers\ColumnFilterTransformer;
+
+class ColumnFilterTransformerTest extends TestCase
+{
+    /** @var ColumnFilterTransformer */
+    protected $transformer;
+
+    public function setUp(): void
+    {
+        $this->transformer = new ColumnFilterTransformer();
+    }
+
+    public function testTransformWithColumnName(): void
+    {
+        $row = new Row(['a' => 'b', 'c' => 'd', 'e' => 'f', 'g' => 'h']);
+
+        $this->transformer->options(['columns' => ['c', 'g']]);
+        $this->transformer->transform($row);
+
+        static::assertSame(['c' => 'd', 'g' => 'h'], $row->toArray());
+    }
+
+    public function testTransformWithCallback(): void
+    {
+        $row = new Row(['a' => 'keep', 'c' => 'drop', 'e' => 'keep', 'g' => 'special']);
+
+        $this->transformer->options([
+            'callback' => function (string $column, string $value): bool {
+                return $column === 'g' || $value === 'keep';
+            },
+        ]);
+        $this->transformer->transform($row);
+
+        static::assertSame(['a' => 'keep', 'e' => 'keep', 'g' => 'special'], $row->toArray());
+    }
+
+    public function testTransformWithBothFilters(): void
+    {
+        $row = new Row(['a' => 'keep', 'c' => 'drop', 'e' => 'keep', 'g' => 'special']);
+
+        $this->transformer->options([
+            'columns' => ['c', 'e'],
+            'callback' => function (string $column, string $value): bool {
+                return $value === 'keep';
+            },
+        ]);
+        $this->transformer->transform($row);
+
+        static::assertSame(['e' => 'keep'], $row->toArray());
+    }
+
+    public function testTransformWithoutFilter(): void
+    {
+        $row = new Row(['a' => 'keep', 'c' => 'drop', 'e' => 'keep', 'g' => 'special']);
+        $expected = clone $row;
+
+        $this->transformer->transform($row);
+
+        static::assertSame($expected->toArray(), $row->toArray());
+    }
+}


### PR DESCRIPTION
Example use case: only keep a few useful column from a large dataset