### PR TITLE
17-Add PHP Infection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.lock
 .DS_Store
 .php_cs.cache
 .phpunit.result.cache
+.idea
+var/

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ phpcsfixer:
 
 test:
 	vendor/bin/phpunit --testdox
+
+infection:
+	vendor/bin/infection

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
+        "infection/infection": "^0.15.3",
         "phpstan/phpstan": "^0.12.7",
         "phpunit/phpunit": "^8.5",
         "squizlabs/php_codesniffer": "^3.5"

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,0 +1,25 @@
+{
+  "source": {
+    "directories": [
+      "src"
+    ]
+  },
+  "timeout": 10,
+  "logs": {
+    "text": "var/tmp-infection/infection.log",
+    "summary": "var/tmp-infection/summary.log",
+    "perMutator": "var/tmp-infection/per-mutator.md"
+  },
+  "tmpDir": "var/tmp-infection",
+  "mutators": {
+    "@default": true,
+    "@function_signature": false,
+    "TrueValue": {
+      "ignore": [
+        "NameSpace\\*\\Class::method"
+      ]
+    }
+  },
+  "testFramework":"phpunit",
+  "testFrameworkOptions": "-vvv"
+}


### PR DESCRIPTION
#17 

331 mutations were generated:
     268 mutants were killed
      38 mutants were not covered by tests
      24 covered mutants were not detected
       0 errors were encountered
       1 time outs were encountered

Metrics:
         Mutation Score Indicator (MSI): 81%
         Mutation Code Coverage: 88%
         Covered Code MSI: 91%
