### PR TITLE
fix Etl input parameter phpdoc

### DIFF
--- a/src/Etl.php
+++ b/src/Etl.php
@@ -39,7 +39,7 @@ class Etl
     /**
      * Extract.
      *
-     * @param string $input
+     * @param mixed $input
      * @param array  $options
      *
      * @return $this

--- a/src/Etl.php
+++ b/src/Etl.php
@@ -39,8 +39,12 @@ class Etl
     /**
      * Extract.
      *
+     * $input cannot be strictly typed
+     * Etl\Extractor\Csv needs a string
+     * Etl\Extractor\Collection an \Iterator
+     *
      * @param mixed $input
-     * @param array  $options
+     * @param array $options
      *
      * @return $this
      */


### PR DESCRIPTION
Fix incorrect phpdoc, Extract $input cannot be strictly typed ex.:
- Collection : input = Iterator
- Csv : input = string (file path)