### PR TITLE
Fix docblock + purge phpstan cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ phpcs:
 	vendor/bin/phpcs
 
 phpstan:
+	vendor/bin/phpstan clear-result-cache
 	vendor/bin/phpstan analyse
 
 phpcsfixer:

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     },
     "require": {
         "php": "~7.2",
-        "flow/jsonpath": "^0.3.1",
-        "infection/infection": "^0.16.1"
+        "flow/jsonpath": "^0.3.1"
     },
     "autoload": {
         "psr-4": {
@@ -28,6 +27,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
+        "infection/infection": "^0.16.2",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12.18",
         "phpstan/phpstan-deprecation-rules": "^0.12.2",

--- a/src/Step.php
+++ b/src/Step.php
@@ -23,7 +23,7 @@ abstract class Step
     /**
      * Set the step options.
      *
-     * @param string[]|int[] $options
+     * @param string[]|int[]|bool[] $options
      *
      * @return $this
      */


### PR DESCRIPTION
1. Update the Makefile: when running PHPSTAN, we clean its cache.
2. Fixing a dockblock.