### PR TITLE
Use Extractor to create a date dimension table.

### DIFF
--- a/docs/Extractors/DateDimension.md
+++ b/docs/Extractors/DateDimension.md
@@ -1,9 +1,9 @@
-# Collection
+# DateDimension
 
-Creates a Date Dimension table for a data warehouse
+Creates a Date Dimension table for a data warehouse.
 
 ```php
-$etl->extract('date_demension', $iterable, $options);
+$etl->extract('date_dimension', $iterable, $options);
 ```
 
 ## Options
@@ -43,7 +43,7 @@ Currently, the default columns are:
  * IsWorkDayKey
 
 ### StartDate
-First day in date dimesnion table.
+First day in date dimension table.
 
 | Type | Default value |
 |----- | ------------- |
@@ -54,7 +54,7 @@ $options = ['startDate' => '2015-01-01T60:00:00-4'];
 ```
 
 ### EndDate
-First day in date dimesnion table.
+Last day in date dimension table.
 
 | Type | Default value |
 |----- | ------------- |

--- a/docs/Extractors/DateDimension.md
+++ b/docs/Extractors/DateDimension.md
@@ -1,0 +1,65 @@
+# Collection
+
+Creates a Date Dimension table for a data warehouse
+
+```php
+$etl->extract('date_demension', $iterable, $options);
+```
+
+## Options
+
+### Columns
+Columns from the iterable item that will be extracted.
+
+| Type | Default value |
+|----- | ------------- |
+| array | `null` |
+
+```php
+$options = ['columns' => ['DateKey', 'DateFull', 'Year', 'Month', 'DayOfMonth']];
+```
+
+Currently, the default columns are:
+
+ * DateKey
+ * DateFullName
+ * DateFull
+ * Year
+ * Quarter
+ * QuarterName
+ * QuarterKey
+ * Month
+ * MonthKey
+ * MonthName
+ * DayOfMonth
+ * NumberOfDaysInTheMonth
+ * DayOfYear
+ * WeekOfYear
+ * WeekOfYearKey
+ * ISOWeek
+ * ISOWeekKey
+ * WeekDay
+ * WeekDayName
+ * IsWorkDayKey
+
+### StartDate
+First day in date dimesnion table.
+
+| Type | Default value |
+|----- | ------------- |
+| array | `5YearsAgo` |
+
+```php
+$options = ['startDate' => '2015-01-01T60:00:00-4'];
+```
+
+### EndDate
+First day in date dimesnion table.
+
+| Type | Default value |
+|----- | ------------- |
+| array | `+5Years` |
+
+```php
+$options = ['startDate' => '2025-01-01T06:00:00+4'];
+```

--- a/docs/Extractors/README.md
+++ b/docs/Extractors/README.md
@@ -12,6 +12,7 @@ $etl->extract($type, $source, $options);
 * [Aggregator](Aggregator.md)
 * [Collection](Collection.md)
 * [CSV](Csv.md)
+* [Date Dimension](DateDimension.md)
 * [Fixed Width](FixedWidth.md)
 * [JSON](Json.md)
 * [Query](Query.md)

--- a/src/Extractors/DateDimension.php
+++ b/src/Extractors/DateDimension.php
@@ -66,8 +66,6 @@ class DateDimension extends Extractor
 
     /**
      * Extract data from the input.
-     *
-     * @return \Generator
      */
     public function extract(): \Generator
     {
@@ -96,16 +94,18 @@ class DateDimension extends Extractor
                 'ISOWeekKey' => $date->format('W'),
                 'WeekDay' => $dayOfWeek,
                 'WeekDayName' => $date->format('l'),
-                'IsWorkDayKey' => ($dayOfWeek === 0 || $dayOfWeek === 6) ? 0 : 1,
+                'IsWorkDayKey' => (0 === $dayOfWeek || 6 === $dayOfWeek) ? 0 : 1,
             ];
-            $date->add($interval);
 
-            if ($this->columns !== null && count($this->columns) > 0) {
+            if (null !== $this->columns && count($this->columns) > 0) {
                 $flipped = array_flip($this->columns);
                 $row = array_intersect_key($row, $flipped);
             }
 
             yield new Row($row);
+
+            // Add one day to set up the next iteraion of the loop.
+            $date->add($interval);
         }
     }
 }

--- a/src/Extractors/DateDimension.php
+++ b/src/Extractors/DateDimension.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @author      Wizacha DevTeam <dev@wizacha.com>
+ * @copyright   Copyright (c) Wizacha
+ * @copyright   Copyright (c) Leonardo Marquine
+ * @license     MIT
+ */
+
+declare(strict_types=1);
+
+namespace Wizaplace\Etl\Extractors;
+
+use Wizaplace\Etl\Row;
+
+/**
+ * Provides a tool to pre-generate a date dimension table.
+ */
+class DateDimension extends Extractor
+{
+    /**
+     * A string representing the start date of the requested dimension table.
+     *
+     * @var string
+     */
+    protected $startDate;
+
+    /**
+     * A string representing the end date of the requested dimension table.
+     *
+     * @var string
+     */
+    protected $endDate;
+
+    /**
+     * Extractor columns.
+     *
+     * @var array|null
+     */
+    protected $columns;
+
+    /**
+     * Properties that can be set via the options method.
+     *
+     * @var string[]
+     */
+    protected $availableOptions = ['columns', 'startDate', 'endDate'];
+
+    public function __construct()
+    {
+        if (!isset($this->startDate)) {
+            $date = new \DateTime();
+            $date->sub(new \DateInterval('P5Y'))
+                ->setDate((int) $date->format('Y'), 1, 1)
+                ->setTime(0, 0, 0);
+            $this->startDate = $date->format('c');
+        }
+        if (!isset($this->endDate)) {
+            $date = new \DateTime();
+            $date->add(new \DateInterval('P5Y'))
+                ->setDate((int) $date->format('Y'), 1, 1)
+                ->setTime(0, 0, 0);
+            $this->endDate = $date->format('c');
+        }
+    }
+
+    /**
+     * Extract data from the input.
+     *
+     * @return \Generator
+     */
+    public function extract(): \Generator
+    {
+        $interval = new \DateInterval('P1D');
+        $date = new \DateTime($this->startDate);
+        $end = new \DateTime($this->endDate);
+        while ($date <= $end) {
+            $dayOfWeek = (int) $date->format('w');
+            $row = [
+                'DateKey' => $date->format('Ymd'),
+                'DateFullName' => $date->format('F j, Y'),
+                'DateFull' => $date->format('c'),
+                'Year' => $date->format('Y'),
+                'Quarter' => (int) ceil($date->format('n') / 4),
+                'QuarterName' => 'Q' . (int) ceil($date->format('n') / 4),
+                'QuarterKey' => (int) ceil($date->format('n') / 4),
+                'Month' => $date->format('n'),
+                'MonthKey' => $date->format('n'),
+                'MonthName' => $date->format('F'),
+                'DayOfMonth' => $date->format('j'),
+                'NumberOfDaysInTheMonth' => $date->format('t'),
+                'DayOfYear' => 1 + (int) $date->format('z'),
+                'WeekOfYear' => $date->format('W'),
+                'WeekOfYearKey' => $date->format('W'),
+                'ISOWeek' => $date->format('W'),
+                'ISOWeekKey' => $date->format('W'),
+                'WeekDay' => $dayOfWeek,
+                'WeekDayName' => $date->format('l'),
+                'IsWorkDayKey' => ($dayOfWeek === 0 || $dayOfWeek === 6) ? 0 : 1,
+            ];
+            $date->add($interval);
+
+            if ($this->columns !== null && count($this->columns) > 0) {
+                $flipped = array_flip($this->columns);
+                $row = array_intersect_key($row, $flipped);
+            }
+
+            yield new Row($row);
+        }
+    }
+}

--- a/src/Extractors/DateDimension.php
+++ b/src/Extractors/DateDimension.php
@@ -104,7 +104,7 @@ class DateDimension extends Extractor
 
             yield new Row($row);
 
-            // Add one day to set up the next iteraion of the loop.
+            // Add one day to set up the next iteration of the loop.
             $date->add($interval);
         }
     }

--- a/tests/Extractors/DateDimensionTest.php
+++ b/tests/Extractors/DateDimensionTest.php
@@ -1,10 +1,19 @@
 <?php
 
+/**
+ * @author      Wizacha DevTeam <dev@wizacha.com>
+ * @copyright   Copyright (c) Wizacha
+ * @copyright   Copyright (c) Leonardo Marquine
+ * @license     MIT
+ */
+
+declare(strict_types=1);
+
 namespace Tests\Extractors;
 
 use Tests\TestCase;
-use Wizaplace\Etl\Row;
 use Wizaplace\Etl\Extractors\DateDimension;
+use Wizaplace\Etl\Row;
 
 class DateDimensionTest extends TestCase
 {
@@ -108,7 +117,8 @@ class DateDimensionTest extends TestCase
         ]);
         $result = iterator_to_array($extractor->extract());
         $this->assertGreaterThan(3650, count($result));
-        $this->assertEquals((new \DateTime())->format('Y') - 5 . '0101', $result[0]['DateKey']);
-        $this->assertEquals((new \DateTime())->format('Y') + 5 . '0101', $result[count($result) - 1]['DateKey']);
+        $year = (int) (new \DateTime())->format('Y');
+        $this->assertEquals($year - 5 . '0101', $result[0]['DateKey']);
+        $this->assertEquals($year + 5 . '0101', $result[count($result) - 1]['DateKey']);
     }
 }

--- a/tests/Extractors/DateDimensionTest.php
+++ b/tests/Extractors/DateDimensionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Extractors;
+
+use Tests\TestCase;
+use Wizaplace\Etl\Row;
+use Wizaplace\Etl\Extractors\DateDimension;
+
+class DateDimensionTest extends TestCase
+{
+    /** @test */
+    public function default_options()
+    {
+        $expected = [
+            new Row([
+                'DateKey' => '20200101',
+                'DateFullName' => 'January 1, 2020',
+                'DateFull' => '2020-01-01T00:00:00+00:00',
+                'Year' => '2020',
+                'Quarter' => 1,
+                'QuarterName' => 'Q1',
+                'QuarterKey' => 1,
+                'Month' => '1',
+                'MonthKey' => '1',
+                'MonthName' => 'January',
+                'DayOfMonth' => '1',
+                'NumberOfDaysInTheMonth' => '31',
+                'DayOfYear' => 1,
+                'WeekOfYear' => '01',
+                'WeekOfYearKey' => '01',
+                'ISOWeek' => '01',
+                'ISOWeekKey' => '01',
+                'WeekDay' => '3',
+                'WeekDayName' => 'Wednesday',
+                'IsWorkDayKey' => 1,
+            ]),
+            new Row([
+                'DateKey' => '20200102',
+                'DateFullName' => 'January 2, 2020',
+                'DateFull' => '2020-01-02T00:00:00+00:00',
+                'Year' => '2020',
+                'Quarter' => 1,
+                'QuarterName' => 'Q1',
+                'QuarterKey' => 1,
+                'Month' => '1',
+                'MonthKey' => '1',
+                'MonthName' => 'January',
+                'DayOfMonth' => '2',
+                'NumberOfDaysInTheMonth' => '31',
+                'DayOfYear' => 2,
+                'WeekOfYear' => '01',
+                'WeekOfYearKey' => '01',
+                'ISOWeek' => '01',
+                'ISOWeekKey' => '01',
+                'WeekDay' => '4',
+                'WeekDayName' => 'Thursday',
+                'IsWorkDayKey' => 1,
+            ]),
+        ];
+
+        $extractor = new DateDimension();
+        $extractor->options(['startDate' => '2020-01-01T00:00:00+0', 'endDate' => '2020-01-02T00:00:00+0']);
+        $this->assertEquals($expected, iterator_to_array($extractor->extract()));
+    }
+
+    /** @test */
+    public function selected_columns()
+    {
+        $expected = [
+            new Row([
+                'DateKey' => '20200101',
+                'DateFull' => '2020-01-01T06:00:00-04:00',
+                'Year' => '2020',
+                'Month' => '1',
+                'DayOfMonth' => '1',
+            ]),
+            new Row([
+                'DateKey' => '20200102',
+                'DateFull' => '2020-01-02T06:00:00-04:00',
+                'Year' => '2020',
+                'Month' => '1',
+                'DayOfMonth' => '2',
+            ]),
+            new Row([
+                'DateKey' => '20200103',
+                'DateFull' => '2020-01-03T06:00:00-04:00',
+                'Year' => '2020',
+                'Month' => '1',
+                'DayOfMonth' => '3',
+            ]),
+        ];
+
+        $extractor = new DateDimension();
+        $extractor->options([
+            'startDate' => '2020-01-01T06:00:00-4',
+            'endDate' => '2020-01-03T06:00:00-4',
+            'columns' => ['DateKey', 'DateFull', 'Year', 'Month', 'DayOfMonth'],
+        ]);
+        $this->assertEquals($expected, iterator_to_array($extractor->extract()));
+    }
+
+    /** @test */
+    public function default_start()
+    {
+        $extractor = new DateDimension();
+        $extractor->options([
+            'columns' => ['DateKey', 'DateFull'],
+        ]);
+        $result = iterator_to_array($extractor->extract());
+        $this->assertGreaterThan(3650, count($result));
+        $this->assertEquals((new \DateTime())->format('Y') - 5 . '0101', $result[0]['DateKey']);
+        $this->assertEquals((new \DateTime())->format('Y') + 5 . '0101', $result[count($result) - 1]['DateKey']);
+    }
+}


### PR DESCRIPTION
I looked around for scripts to create a Date Dimension table for our warehouse and they were all way more complex and platform specific than they needed to be. Thinking of it as an extractor allowed me to implement in a fairly small number of lines of code, and to actually create the table becomes a trivial ETL.

I intentionally left holidays and fiscal periods out of the Extraction since they vary from country to country and company to company. I expect holidays and fiscal would either be implemented as Transform or would be entered into the resulting Date Dimension table manually. The manual option is made more practical with the option in #41 which adds an option to InsertUpdate to only add new rows and not overwrite them.