### PR TITLE
Remove PHPStan failures in Xml.php

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           at: .
       - run:
           name: phpstan
-          command: vendor/bin/phpstan analyse
+          command: vendor/bin/phpstan analyse --memory-limit=256M
 
   phpunit7-2:
     executor: php7-2

--- a/src/Extractors/Xml.php
+++ b/src/Extractors/Xml.php
@@ -32,7 +32,7 @@ class Xml extends Extractor
     /**
      * XML Reader.
      *
-     * @var \XMLReader
+     * @var \XMLReader|bool
      */
     protected $reader;
 
@@ -70,9 +70,10 @@ class Xml extends Extractor
             }
         }
 
-        $this->reader = new \XMLReader();
-
-        $this->reader->open($this->input);
+        $this->reader = \XMLReader::open($this->input);
+        if (false === $this->reader) {
+            throw new XmlException('Could not open XMLReader.');
+        }
 
         while ($this->reader->read()) {
             $this->addElementToPath();

--- a/src/Extractors/XmlException.php
+++ b/src/Extractors/XmlException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Wizaplace\Etl\Extractors;
+
+class XmlException extends \RuntimeException
+{
+
+}


### PR DESCRIPTION
This is just a bit of cleanup so PHPStan can pass.

I also added memory to the scanner invocation because the logs on CircleCI show that sometimes it is failing for lack of memory rather than the violation it flagged in Xml.php