### PR TITLE
XmlException class is unused and should be removed.

### DIFF
--- a/src/Extractors/XmlException.php
+++ b/src/Extractors/XmlException.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Wizaplace\Etl\Extractors;
-
-class XmlException extends \RuntimeException
-{
-}


### PR DESCRIPTION
XmlException class is unused.

It was added to support XMLReader::open() which had been suggested by PHPStan, but was later reverted because it will issue an E_STRICT error in PHP.