### PR TITLE
add support for PHP8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,10 @@ executors:
     docker:
       - image: php:7.4-alpine
     working_directory: ~/repo
+  php8-0:
+    docker:
+      - image: php:8.0-alpine
+    working_directory: ~/repo
 
 jobs:
   # The complete list : all in the minimum PHP version supported.
@@ -144,6 +148,42 @@ jobs:
           name: phpunit
           command: vendor/bin/phpunit --testdox
 
+  composer8-0:
+    executor: php8-0
+    steps:
+      - run:
+          name: Install alpine requirements for checkout
+          command: apk add git openssh-client curl
+      - checkout
+      - restore_cache:
+          key: composer-{{ checksum "composer.json" }}-{{ checksum "composer.lock" }}
+      - run:
+          name: composer
+          command: |
+            if [[ ! -f vendor/autoload.php ]]; then
+                curl https://getcomposer.org/composer-stable.phar --location --silent  --output /usr/bin/composer; \
+                chmod +x /usr/bin/composer; \
+                composer install --no-progress --no-interaction; \
+            fi
+      - save_cache:
+          key: composer-{{ checksum "composer.json" }}-{{ checksum "composer.lock" }}
+          paths:
+            - ./vendor
+      - persist_to_workspace:
+          root: .
+          paths:
+            - vendor
+
+  phpunit8-0:
+    executor: php8-0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: phpunit
+          command: vendor/bin/phpunit --testdox
+
 workflows:
   version: '2.1'
   Code quality:
@@ -151,6 +191,7 @@ workflows:
       - composer7-2
       - composer7-3
       - composer7-4
+      - composer8-0
       - phpcs7-2:
           requires:
             - composer7-2
@@ -166,3 +207,6 @@ workflows:
       - phpunit7-4:
           requires:
             - composer7-4
+      - phpunit8-0:
+          requires:
+            - composer8-0

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "~7.2",
+        "php": "~7.2|~8.0",
         "softcreatr/jsonpath": "^0.7.2"
     },
     "autoload": {
@@ -30,13 +30,13 @@
         "ext-json": "*",
         "ext-pdo_sqlite": "*",
         "ext-xmlreader": "*",
-        "friendsofphp/php-cs-fixer": "^2.16",
-        "infection/infection": "^0.15.3",
+        "friendsofphp/php-cs-fixer": "^2.17",
+        "infection/infection": ">=0.15",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12.18",
         "phpstan/phpstan-deprecation-rules": "^0.12.2",
         "phpstan/phpstan-strict-rules": "^0.12.2",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": ">=8",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload-dev": {

--- a/src/Row.php
+++ b/src/Row.php
@@ -151,11 +151,9 @@ class Row implements \ArrayAccess
      *
      * @param mixed $value
      */
-    public function __set(string $key, $value): self
+    public function __set(string $key, $value): void
     {
         $this->attributes[$key] = $value;
-
-        return $this;
     }
 
     /**

--- a/tests/Extractors/CsvTest.php
+++ b/tests/Extractors/CsvTest.php
@@ -108,8 +108,14 @@ class CsvTest extends TestCase
                 $count++;
             }
         } catch (\Throwable $exception) {
+            if (phpversion() < 8) {
+                $expectedMessage = 'Undefined offset: 2';
+            } else {
+                $expectedMessage = 'Undefined array key 2';
+            }
+
             static::assertEquals(
-                'Undefined offset: 2',
+                $expectedMessage,
                 $exception->getMessage()
             );
         }
@@ -146,8 +152,14 @@ class CsvTest extends TestCase
                 $count++;
             }
         } catch (\Throwable $exception) {
+            if (phpversion() < 8) {
+                $expectedMessage = 'Undefined offset: 2';
+            } else {
+                $expectedMessage = 'Undefined array key 2';
+            }
+
             static::assertEquals(
-                'Undefined offset: 2',
+                $expectedMessage,
                 $exception->getMessage()
             );
         }

--- a/tests/Extractors/QueryTest.php
+++ b/tests/Extractors/QueryTest.php
@@ -42,7 +42,7 @@ class QueryTest extends TestCase
     public function custom_connection_and_bindings()
     {
         $statement = $this->createMock('PDOStatement');
-        $statement->expects($this->once())->method('execute')->with('bindings');
+        $statement->expects($this->once())->method('execute')->with(['bindings']);
         $statement->expects($this->exactly(3))->method('fetch')
             ->will($this->onConsecutiveCalls(['row1'], ['row2'], null));
 
@@ -57,7 +57,7 @@ class QueryTest extends TestCase
         $extractor->input('select query');
         $extractor->options([
             'connection' => 'connection',
-            'bindings' => 'bindings',
+            'bindings' => ['bindings'],
         ]);
 
         static::assertEquals([new Row(['row1']), new Row(['row2'])], iterator_to_array($extractor->extract()));

--- a/tests/Extractors/QueryTest.php
+++ b/tests/Extractors/QueryTest.php
@@ -42,7 +42,7 @@ class QueryTest extends TestCase
     public function custom_connection_and_bindings()
     {
         $statement = $this->createMock('PDOStatement');
-        $statement->expects($this->once())->method('execute')->with(['bindings']);
+        $statement->expects($this->once())->method('execute')->with(['binding']);
         $statement->expects($this->exactly(3))->method('fetch')
             ->will($this->onConsecutiveCalls(['row1'], ['row2'], null));
 
@@ -57,7 +57,7 @@ class QueryTest extends TestCase
         $extractor->input('select query');
         $extractor->options([
             'connection' => 'connection',
-            'bindings' => ['bindings'],
+            'bindings' => ['binding'],
         ]);
 
         static::assertEquals([new Row(['row1']), new Row(['row2'])], iterator_to_array($extractor->extract()));


### PR DESCRIPTION
#54 

- Add support for PHP8.0
- Remove blocking issue added in https://github.com/wizaplace/php-etl/pull/4/files (so, we might have a BC if someone rely on this one)

May be it is time to consider a 2.0 to drop all the old stuff and have a fresh base for new features.