### PR TITLE
Resolve uncovered code in transaction class

### DIFF
--- a/docs/Loaders/Insert.md
+++ b/docs/Loaders/Insert.md
@@ -55,6 +55,10 @@ $options = ['timestamps' => true];
 ### Transaction
 Indicates if the loader will perform database transactions.
 
+If run in a single transaction, treat the ETL process as a single atomic transaction and roll back on errors. If
+run in multiple transactions, the best we can do is provide durability by trying to commit any inserts that are
+accepted by the destination database.
+
 | Type | Default value |
 |----- | ------------- |
 | boolean | `true` |
@@ -65,6 +69,18 @@ $options = ['transaction' => false];
 
 ### Commit Size
 Transaction commit size. The transaction option must be enabled.
+
+The work in done in a single transaction if commit size is zero, and we want to roll back that transaction if an
+insert fails. In that manner, the ETL process becomes ACID in that either all the inserts are committed or none
+are. If the ETL process fails, we can replay the entire source after fixing the error.
+
+If the work is done in multiple transactions, however, some transactions may have already been committed. The
+inserts from later pending transactions therefore are not atomic or durable in the sense that the pipeline
+can fail and inserts that are accepted still need to be committed. This would leave the database in a state
+where it is difficult to determine which inserts have been accepted and which have not. Therefore, we try to
+commit the pending transaction so any rows that have been reported as inserted will be durable in the database.
+In terms of ACID properties of the destination database, since committing multiple transactions implies the
+ETL process is not atomic, at least we can be durable.
 
 | Type | Default value |
 |----- | ------------- |

--- a/docs/Loaders/InsertUpdate.md
+++ b/docs/Loaders/InsertUpdate.md
@@ -82,6 +82,10 @@ $options = ['timestamps' => true];
 ### Transaction
 Indicates if the loader will perform database transactions.
 
+If run in a single transaction, treat the ETL process as a single atomic transaction and roll back on errors. If
+run in multiple transactions, the best we can do is provide durability by trying to commit any inserts that are
+accepted by the destination database.
+
 | Type | Default value |
 |----- | ------------- |
 | boolean | `true` |
@@ -92,6 +96,18 @@ $options = ['transaction' => false];
 
 ### Commit Size
 Transaction commit size. The transaction option must be enabled.
+
+The work in done in a single transaction if commit size is zero, and we want to roll back that transaction if an
+insert fails. In that manner, the ETL process becomes ACID in that either all the inserts are committed or none
+are. If the ETL process fails, we can replay the entire source after fixing the error.
+
+If the work is done in multiple transactions, however, some transactions may have already been committed. The
+inserts from later pending transactions therefore are not atomic or durable in the sense that the pipeline
+can fail and inserts that are accepted still need to be committed. This would leave the database in a state
+where it is difficult to determine which inserts have been accepted and which have not. Therefore, we try to
+commit the pending transaction so any rows that have been reported as inserted will be durable in the database.
+In terms of ACID properties of the destination database, since committing multiple transactions implies the
+ETL process is not atomic, at least we can be durable.
 
 | Type | Default value |
 |----- | ------------- |

--- a/src/Database/Transaction.php
+++ b/src/Database/Transaction.php
@@ -43,6 +43,18 @@ class Transaction
 
     /**
      * Code defensively by closing any open transactions when this object is destroyed.
+     *
+     * If this work in done in a single transaction, we want to roll back that transaction if in insert fails. In
+     * that manner, the ETL process becomes ACID in that either all of the inserts are committed or none are. If
+     * the ETL process fails, we can replay the entire source after fixing the error.
+     *
+     * If the work is done in multiple transactions, however, some transactions may have already been committed. The
+     * inserts from later pending transactions therefore are not atomic or durable in the sense that the pipeline
+     * can fail and inserts that are accepted still need to be committed. This would leave the database in a state
+     * where it is difficult to determine which inserts have been accepted and which have not. Therefore, we try to
+     * commit the pending transaction so any rows that have been reported as inserted will be durable in the database.
+     * In terms of ACID properties of the destination database, since committing multiple transactions implies the
+     * ETL process is not atomic, at least we can be durable.
      */
     public function __destruct()
     {
@@ -66,7 +78,11 @@ class Transaction
     }
 
     /**
-     * Run the given callback inside a transaction.
+     * Run the given callback inside a transaction or multiple transactions.
+     *
+     * If run in a single transaction, treat the ETL process as a single atomic transaction and roll back on errors. If
+     * run in multiple transactions, the best we can do is provide durability by trying to commit any inserts that are
+     * accepted by the destination database.
      *
      * @throws \Exception
      */

--- a/src/Database/Transaction.php
+++ b/src/Database/Transaction.php
@@ -42,6 +42,14 @@ class Transaction
     }
 
     /**
+     * Code defensively by closing any open transactions when this object is destroyed.
+     */
+    public function __destruct()
+    {
+        $this->close();
+    }
+
+    /**
      * Set the commit size.
      *
      * @return $this
@@ -82,7 +90,7 @@ class Transaction
      */
     protected function shouldBeginTransaction(): bool
     {
-        return !$this->open && (0 === $this->size || 1 === $this->count);
+        return !$this->open;
     }
 
     /**

--- a/src/Database/Transaction.php
+++ b/src/Database/Transaction.php
@@ -46,7 +46,11 @@ class Transaction
      */
     public function __destruct()
     {
-        $this->close();
+        if ($this->size > 0) {
+            $this->close();
+        } elseif ($this->pdo->inTransaction()) {
+            $this->pdo->rollBack();
+        }
     }
 
     /**

--- a/src/Database/Transaction.php
+++ b/src/Database/Transaction.php
@@ -63,6 +63,8 @@ class Transaction
 
     /**
      * Run the given callback inside a transaction.
+     *
+     * @throws \Exception
      */
     public function run(callable $callback): void
     {
@@ -75,8 +77,9 @@ class Transaction
         try {
             call_user_func($callback);
         } catch (\Exception $exception) {
-            $this->pdo->rollBack();
-
+            if ($this->pdo->inTransaction()) {
+                $this->pdo->commit();
+            }
             throw $exception;
         }
 
@@ -119,7 +122,9 @@ class Transaction
         $this->open = false;
         $this->count = 0;
 
-        $this->pdo->commit();
+        if ($this->pdo->inTransaction()) {
+            $this->pdo->commit();
+        }
     }
 
     /**

--- a/src/Database/Transaction.php
+++ b/src/Database/Transaction.php
@@ -78,7 +78,11 @@ class Transaction
             call_user_func($callback);
         } catch (\Exception $exception) {
             if ($this->pdo->inTransaction()) {
-                $this->pdo->commit();
+                if (0 === $this->size) {
+                    $this->pdo->rollBack();
+                } else {
+                    $this->pdo->commit();
+                }
             }
             throw $exception;
         }

--- a/src/Loaders/Insert.php
+++ b/src/Loaders/Insert.php
@@ -42,7 +42,7 @@ class Insert extends Loader
     /**
      * Transaction commit size.
      */
-    protected int $commitSize = 100;
+    protected int $commitSize = 0;
 
     /**
      * Time for timestamps columns.

--- a/src/Loaders/InsertUpdate.php
+++ b/src/Loaders/InsertUpdate.php
@@ -54,7 +54,7 @@ class InsertUpdate extends Loader
     /**
      * Transaction commit size.
      */
-    protected int $commitSize = 100;
+    protected int $commitSize = 0;
 
     /**
      * Time for timestamps columns.

--- a/tests/Loaders/InsertTest.php
+++ b/tests/Loaders/InsertTest.php
@@ -73,7 +73,7 @@ class InsertTest extends TestCase
         $this->manager->expects(static::once())->method('statement')->with('default');
         $this->manager->expects(static::once())->method('transaction')->with('default');
 
-        $this->transaction->expects(static::once())->method('size')->with(100);
+        $this->transaction->expects(static::once())->method('size')->with(0);
         $this->transaction->expects(static::once())->method('run');
         $this->transaction->expects(static::once())->method('close');
 

--- a/tests/Loaders/InsertUpdateTest.php
+++ b/tests/Loaders/InsertUpdateTest.php
@@ -120,7 +120,7 @@ class InsertUpdateTest extends TestCase
 
         $this->update->expects(static::never())->method('execute');
 
-        $this->transaction->expects(static::once())->method('size')->with(100);
+        $this->transaction->expects(static::once())->method('size')->with(0);
         $this->transaction->expects(static::once())->method('run');
         $this->transaction->expects(static::once())->method('close');
 
@@ -144,7 +144,7 @@ class InsertUpdateTest extends TestCase
 
         $this->insert->expects(static::never())->method('execute');
 
-        $this->transaction->expects(static::once())->method('size')->with(100);
+        $this->transaction->expects(static::once())->method('size')->with(0);
         $this->transaction->expects(static::once())->method('run');
         $this->transaction->expects(static::once())->method('close');
 
@@ -168,7 +168,7 @@ class InsertUpdateTest extends TestCase
 
         $this->update->expects(static::never())->method('execute');
 
-        $this->transaction->expects(static::once())->method('size')->with(100);
+        $this->transaction->expects(static::once())->method('size')->with(0);
         $this->transaction->expects(static::once())->method('run');
         $this->transaction->expects(static::once())->method('close');
 
@@ -194,7 +194,7 @@ class InsertUpdateTest extends TestCase
 
         $this->insert->expects(static::never())->method('execute');
 
-        $this->transaction->expects(static::once())->method('size')->with(100);
+        $this->transaction->expects(static::once())->method('size')->with(0);
         $this->transaction->expects(static::once())->method('run');
         $this->transaction->expects(static::once())->method('close');
 
@@ -223,7 +223,7 @@ class InsertUpdateTest extends TestCase
 
         $this->insert->expects(static::never())->method('execute');
 
-        $this->transaction->expects(static::once())->method('size')->with(100);
+        $this->transaction->expects(static::once())->method('size')->with(0);
         $this->transaction->expects(static::once())->method('run');
 
         $this->execute($this->loader, [$this->row]);


### PR DESCRIPTION
 - If using transactions, any row should open a PDO transaction if one is not already open
 - If a Transaction class is destroyed, any open transactions should be closed
 - Refactor TransactionTest to provide coverage, reduce code duplication, and remove unused variables.

Resolves #76