### PR TITLE
Fixes for DateDimension generator

### DIFF
--- a/src/Extractors/DateDimension.php
+++ b/src/Extractors/DateDimension.php
@@ -51,15 +51,13 @@ class DateDimension extends Extractor
         if (!isset($this->startDate)) {
             $date = new \DateTime();
             $date->sub(new \DateInterval('P5Y'))
-                ->setDate((int) $date->format('Y'), 1, 1)
-                ->setTime(0, 0, 0);
+                ->setDate((int) $date->format('Y'), 1, 1);
             $this->startDate = $date->format('c');
         }
         if (!isset($this->endDate)) {
             $date = new \DateTime();
             $date->add(new \DateInterval('P5Y'))
-                ->setDate((int) $date->format('Y'), 1, 1)
-                ->setTime(0, 0, 0);
+                ->setDate((int) $date->format('Y'), 1, 1);
             $this->endDate = $date->format('c');
         }
     }
@@ -74,14 +72,15 @@ class DateDimension extends Extractor
         $end = new \DateTime($this->endDate);
         while ($date <= $end) {
             $dayOfWeek = (int) $date->format('w');
+            $quarter = (int) ceil($date->format('n') / 3);
             $row = [
                 'DateKey' => $date->format('Ymd'),
                 'DateFullName' => $date->format('F j, Y'),
                 'DateFull' => $date->format('c'),
                 'Year' => $date->format('Y'),
-                'Quarter' => (int) ceil($date->format('n') / 4),
-                'QuarterName' => 'Q' . (int) ceil($date->format('n') / 4),
-                'QuarterKey' => (int) ceil($date->format('n') / 4),
+                'Quarter' => $quarter,
+                'QuarterName' => "Q$quarter",
+                'QuarterKey' => $quarter,
                 'Month' => $date->format('n'),
                 'MonthKey' => $date->format('n'),
                 'MonthName' => $date->format('F'),

--- a/src/Extractors/DateDimension.php
+++ b/src/Extractors/DateDimension.php
@@ -49,16 +49,18 @@ class DateDimension extends Extractor
     public function __construct()
     {
         if (!isset($this->startDate)) {
-            $date = new \DateTime();
-            $date->sub(new \DateInterval('P5Y'))
-                ->setDate((int) $date->format('Y'), 1, 1);
-            $this->startDate = $date->format('c');
+            $start = new \DateTime();
+            $start->sub(new \DateInterval('P5Y'))
+                ->setDate((int) $start->format('Y'), 1, 1)
+                ->setTime(0, 0);
+            $this->startDate = $start->format('c');
         }
         if (!isset($this->endDate)) {
-            $date = new \DateTime();
-            $date->add(new \DateInterval('P5Y'))
-                ->setDate((int) $date->format('Y'), 1, 1);
-            $this->endDate = $date->format('c');
+            $end = new \DateTime();
+            $end->add(new \DateInterval('P5Y'))
+                ->setDate((int) $end->format('Y'), 1, 1)
+                ->sub(new \DateInterval('P1D'));
+            $this->endDate = $end->format('c');
         }
     }
 

--- a/tests/Extractors/DateDimensionTest.php
+++ b/tests/Extractors/DateDimensionTest.php
@@ -22,53 +22,75 @@ class DateDimensionTest extends TestCase
     {
         $expected = [
             new Row([
-                'DateKey' => '20200101',
-                'DateFullName' => 'January 1, 2020',
-                'DateFull' => '2020-01-01T00:00:00+00:00',
+                'DateKey' => '20200404',
+                'DateFullName' => 'April 4, 2020',
+                'DateFull' => '2020-04-04T00:00:00+00:00',
                 'Year' => '2020',
-                'Quarter' => 1,
-                'QuarterName' => 'Q1',
-                'QuarterKey' => 1,
-                'Month' => '1',
-                'MonthKey' => '1',
-                'MonthName' => 'January',
-                'DayOfMonth' => '1',
-                'NumberOfDaysInTheMonth' => '31',
-                'DayOfYear' => 1,
-                'WeekOfYear' => '01',
-                'WeekOfYearKey' => '01',
-                'ISOWeek' => '01',
-                'ISOWeekKey' => '01',
-                'WeekDay' => '3',
-                'WeekDayName' => 'Wednesday',
-                'IsWorkDayKey' => 1,
+                'Quarter' => 2,
+                'QuarterName' => 'Q2',
+                'QuarterKey' => 2,
+                'Month' => '4',
+                'MonthKey' => '4',
+                'MonthName' => 'April',
+                'DayOfMonth' => '4',
+                'NumberOfDaysInTheMonth' => '30',
+                'DayOfYear' => 95,
+                'WeekOfYear' => '14',
+                'WeekOfYearKey' => '14',
+                'ISOWeek' => '14',
+                'ISOWeekKey' => '14',
+                'WeekDay' => '6',
+                'WeekDayName' => 'Saturday',
+                'IsWorkDayKey' => 0,
             ]),
             new Row([
-                'DateKey' => '20200102',
-                'DateFullName' => 'January 2, 2020',
-                'DateFull' => '2020-01-02T00:00:00+00:00',
+                'DateKey' => '20200405',
+                'DateFullName' => 'April 5, 2020',
+                'DateFull' => '2020-04-05T00:00:00+00:00',
                 'Year' => '2020',
-                'Quarter' => 1,
-                'QuarterName' => 'Q1',
-                'QuarterKey' => 1,
-                'Month' => '1',
-                'MonthKey' => '1',
-                'MonthName' => 'January',
-                'DayOfMonth' => '2',
-                'NumberOfDaysInTheMonth' => '31',
-                'DayOfYear' => 2,
-                'WeekOfYear' => '01',
-                'WeekOfYearKey' => '01',
-                'ISOWeek' => '01',
-                'ISOWeekKey' => '01',
-                'WeekDay' => '4',
-                'WeekDayName' => 'Thursday',
+                'Quarter' => 2,
+                'QuarterName' => 'Q2',
+                'QuarterKey' => 2,
+                'Month' => '4',
+                'MonthKey' => '4',
+                'MonthName' => 'April',
+                'DayOfMonth' => '5',
+                'NumberOfDaysInTheMonth' => '30',
+                'DayOfYear' => 96,
+                'WeekOfYear' => '14',
+                'WeekOfYearKey' => '14',
+                'ISOWeek' => '14',
+                'ISOWeekKey' => '14',
+                'WeekDay' => '0',
+                'WeekDayName' => 'Sunday',
+                'IsWorkDayKey' => 0,
+            ]),
+            new Row([
+                'DateKey' => '20200406',
+                'DateFullName' => 'April 6, 2020',
+                'DateFull' => '2020-04-06T00:00:00+00:00',
+                'Year' => '2020',
+                'Quarter' => 2,
+                'QuarterName' => 'Q2',
+                'QuarterKey' => 2,
+                'Month' => '4',
+                'MonthKey' => '4',
+                'MonthName' => 'April',
+                'DayOfMonth' => '6',
+                'NumberOfDaysInTheMonth' => '30',
+                'DayOfYear' => 97,
+                'WeekOfYear' => '15',
+                'WeekOfYearKey' => '15',
+                'ISOWeek' => '15',
+                'ISOWeekKey' => '15',
+                'WeekDay' => '1',
+                'WeekDayName' => 'Monday',
                 'IsWorkDayKey' => 1,
             ]),
         ];
 
         $extractor = new DateDimension();
-        $extractor->options(['startDate' => '2020-01-01T00:00:00+0', 'endDate' => '2020-01-02T00:00:00+0']);
+        $extractor->options(['startDate' => '2020-04-04T00:00:00+0', 'endDate' => '2020-04-06T00:00:00+0']);
         static::assertEquals($expected, iterator_to_array($extractor->extract()));
     }
 
@@ -104,6 +126,37 @@ class DateDimensionTest extends TestCase
             'startDate' => '2020-01-01T06:00:00-4',
             'endDate' => '2020-01-03T06:00:00-4',
             'columns' => ['DateKey', 'DateFull', 'Year', 'Month', 'DayOfMonth'],
+        ]);
+        static::assertEquals($expected, iterator_to_array($extractor->extract()));
+    }
+
+    /** @test */
+    public function quarters(): void
+    {
+        $quarters = array_merge(
+            array_fill(0, 31, 1),
+            array_fill(0, 28, 1),
+            array_fill(0, 31, 1),
+            array_fill(0, 30, 2),
+            array_fill(0, 31, 2),
+            array_fill(0, 30, 2),
+            array_fill(0, 31, 3),
+            array_fill(0, 31, 3),
+            array_fill(0, 30, 3),
+            array_fill(0, 31, 4),
+            array_fill(0, 30, 4),
+            array_fill(0, 31, 4)
+        );
+        $expected = [];
+        foreach ($quarters as $quarter) {
+            $expected[] = new Row(['Quarter' => $quarter, 'QuarterName' => "Q$quarter"]);
+        }
+
+        $extractor = new DateDimension();
+        $extractor->options([
+            'startDate' => '2021-01-01T06:00:00-4',
+            'endDate' => '2021-12-31T06:00:00-4',
+            'columns' => ['Quarter', 'QuarterName'],
         ]);
         static::assertEquals($expected, iterator_to_array($extractor->extract()));
     }

--- a/tests/Extractors/DateDimensionTest.php
+++ b/tests/Extractors/DateDimensionTest.php
@@ -164,14 +164,21 @@ class DateDimensionTest extends TestCase
     /** @test */
     public function defaultStart(): void
     {
+        ini_set('date.timezone', 'America/New_York');
+        $year = (int) (new \DateTime())->format('Y');
+        $offset = (new \DateTime())->format('P');
+
         $extractor = new DateDimension();
         $extractor->options([
             'columns' => ['DateKey', 'DateFull'],
         ]);
         $result = iterator_to_array($extractor->extract());
+
+        static::assertStringEndsWith("00:00:00$offset", $result[0]['DateFull']);
+        static::assertStringEndsWith("00:00:00$offset", $result[count($result) - 1]['DateFull']);
+        static::assertStringContainsString('12-31', $result[count($result) - 1]['DateFull']);
         static::assertGreaterThan(3650, count($result));
-        $year = (int) (new \DateTime())->format('Y');
         static::assertEquals($year - 5 . '0101', $result[0]['DateKey']);
-        static::assertEquals($year + 5 . '0101', $result[count($result) - 1]['DateKey']);
+        static::assertEquals($year + 4 . '1231', $result[count($result) - 1]['DateKey']);
     }
 }


### PR DESCRIPTION
- Fix bug in calculating quarters
- Improve coverage reported by infection
- Default date range starts on January 1 so it should end on December 31 to be non-overlapping
- Timezone should be tested also