### PR TITLE
Add pull method to row

### DIFF
--- a/src/Row.php
+++ b/src/Row.php
@@ -69,7 +69,6 @@ class Row implements \ArrayAccess
     /**
      * Get a row attribute, and remove it.
      *
-     * @param string $key
      * @return mixed
      */
     public function pull(string $key)

--- a/src/Row.php
+++ b/src/Row.php
@@ -67,6 +67,21 @@ class Row implements \ArrayAccess
     }
 
     /**
+     * Get a row attribute, and remove it.
+     *
+     * @param string $key
+     * @return mixed
+     */
+    public function pull(string $key)
+    {
+        $value = $this->attributes[$key] ?? null;
+
+        unset($this->attributes[$key]);
+
+        return $value;
+    }
+
+    /**
      * Transform the given columns using a callback.
      *
      * @param string[] $columns

--- a/tests/RowTest.php
+++ b/tests/RowTest.php
@@ -45,6 +45,17 @@ class RowTest extends TestCase
     }
 
     /** @test */
+    public function pullAttribute(): void
+    {
+        $row = new Row(['name' => 'Jane Doe']);
+
+        $value = $row->pull('name');
+
+        static::assertEquals('Jane Doe', $value);
+        static::assertNull($row->get('name'));
+    }
+
+    /** @test */
     public function transformValuesUsingCallback(): void
     {
         $row = new Row(['name' => 'Jane Doe', 'email' => 'janedoe@example.com']);


### PR DESCRIPTION
This PR adds a shortcut/convenience method `pull()` to `Row` for quickly getting the value of an attribute and then removing it.